### PR TITLE
Add `dev` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Guide code for building a simple blog that uses Prismic+Next+Now",
   "main": "index.js",
   "scripts": {
+    "dev": "next",
     "build": "next build",
     "deploy": "now"
   },


### PR DESCRIPTION
This pull request adds a default `dev` script to the `package.json` so that users may run a local development environment without installing next globally and running `next` themselves.

You can start the development environment using `yarn dev` after this update.